### PR TITLE
Add HTML message rendering support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fontsource/open-sans": "*",
         "@vitejs/plugin-react": "*",
+        "dompurify": "*",
         "prop-types": "*",
         "react": "*",
         "react-dom": "*",
@@ -1166,6 +1167,11 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-F9e6wPGtY+8KNMRAVfxeCOHU0/NPWMSENNq4pQctuXRqqdEPW7q3CrLbR5Nse044WwacyjHGOMlvNsBe1y6z9A=="
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.490",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@fontsource/open-sans": "*",
     "@vitejs/plugin-react": "*",
+    "dompurify": "*",
     "prop-types": "*",
     "react": "*",
     "react-dom": "*",

--- a/src/components/PublicMessage.jsx
+++ b/src/components/PublicMessage.jsx
@@ -1,3 +1,4 @@
+import DOMPurify from 'dompurify';
 import PropTypes from 'prop-types';
 import classNames from './PublicMessage.module.css';
 
@@ -5,7 +6,7 @@ import classNames from './PublicMessage.module.css';
  * Component that displays a message within a {@link PublicMessageBoard}.
  *
  * @constructor
- * @param {String} message - the text content of the message to be displayed.
+ * @param {String} message - the text content of the message to be displayed (HTML Supported).
  * @param {Array} routes - list of routes affected.
  * @return {JSX.Element}
  */
@@ -28,9 +29,7 @@ export default function PublicMessage({message, routes}) {
           ))}
         </th>
       )}
-      <td colSpan={(routes) ? 1 : 2}>
-        {message}
-      </td>
+      <td colSpan={(routes) ? 1 : 2} dangerouslySetInnerHTML={{__html: DOMPurify.sanitize(message)}} />
     </tr>
   );
 }

--- a/src/hooks/usePublicMessages.js
+++ b/src/hooks/usePublicMessages.js
@@ -3,7 +3,7 @@ import {useCallback, useEffect, useMemo, useState} from 'react';
 /**
  * @typedef PublicMessageObject
  * @property {Number} id - a unique id for the message, from InfoPoint
- * @property {String} message - the text for a public message.
+ * @property {String} message - the text for a public message (HTML Supported).
  * @property {[RouteObject]|null} routes - list of routes affected by this message, null if message is general.
  * @property {Number|null} sortOrder - a pre-set sort order determined by the routes, if applicable.
  */


### PR DESCRIPTION
Closes #21

Went with DOMPurify due to its (relative) ubiquity and no-dependency approach (sanitize-html has a _direct_ dependency on postcss, amongst others???).

