### PR TITLE
Make links within the iframe behave normally

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base target="_parent" />
     <link rel="stylesheet" href="/src/index.css" />
     <script type="module" src="/src/index.jsx"></script>
     <title>Public Message Board</title>


### PR DESCRIPTION
adds a <base target="_parent" /> tag to the html head so that links open
in the parent window rather than the frame itself

Closes #35
