### PR TITLE
Fix JSDoc/PropTypes in `PublicMessage.jsx`

### DIFF
--- a/src/components/PublicMessage.jsx
+++ b/src/components/PublicMessage.jsx
@@ -8,7 +8,7 @@ import classNames from './PublicMessage.module.css';
  * @constructor
  * @param {String} message - the text content of the message to be displayed (HTML Supported).
  * @param {Number} priority - the "priority" level specified by Avail.
- * @param {Array} routes - list of routes affected.
+ * @param {Array|undefined} routes - list of routes affected. Left undefined if message is an error
  * @return {JSX.Element}
  */
 export default function PublicMessage({message, priority, routes}) {
@@ -40,7 +40,6 @@ export default function PublicMessage({message, priority, routes}) {
 }
 
 PublicMessage.propTypes = {
-  id: PropTypes.number,
   message: PropTypes.string.isRequired,
   priority: PropTypes.number,
   routes: PropTypes.array,


### PR DESCRIPTION
Discovered some sillyness in `PublicMessage.jsx` leftover from #8. Looks like `id` was an old implementation attempt and I just didn't update the JSDoc properly when I finished implementation?