### PR TITLE
Remove usages of message priorities

### DIFF
--- a/src/components/PublicMessage.jsx
+++ b/src/components/PublicMessage.jsx
@@ -6,11 +6,10 @@ import classNames from './PublicMessage.module.css'
  *
  * @constructor
  * @param {String} message - the text content of the message to be displayed (HTML Supported).
- * @param {Number|undefined} priority - the "priority" level specified by Avail.
  * @param {Array|undefined} routes - list of routes affected. Left undefined if message is an error
  * @return {JSX.Element}
  */
-export default function PublicMessage ({ message, priority, routes }) {
+export default function PublicMessage ({ message, routes }) {
   return (
     <tr>
       {(routes) && (
@@ -29,15 +28,7 @@ export default function PublicMessage ({ message, priority, routes }) {
           ))}
         </th>
       )}
-      <td
-        className={
-          (typeof (priority) === 'number')
-            ? `${classNames['priority']} ${classNames[`priority-${priority}`]}`
-            : undefined
-        }
-        colSpan={(routes) ? 1 : 2}
-        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(message) }}
-      />
+      <td colSpan={(routes) ? 1 : 2} dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(message) }} />
     </tr>
   )
 }

--- a/src/components/PublicMessage.module.css
+++ b/src/components/PublicMessage.module.css
@@ -10,23 +10,3 @@
 .route-abbreviation:last-of-type {
   margin-bottom: 0;
 }
-
-.priority {
-  border-right: thick solid transparent;
-}
-
-.priority-0 {
-  border-right-color: #f00;
-}
-
-.priority-1 {
-  border-right-color: #f60;
-}
-
-.priority-2 {
-  border-right-color: #fc0;
-}
-
-.priority-3 {
-  border-right-color: #0f0;
-}

--- a/src/hooks/usePublicMessages.js
+++ b/src/hooks/usePublicMessages.js
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
  * @typedef PublicMessageObject
  * @property {Number} id - a unique id for the message, from InfoPoint
  * @property {String} message - the text for a public message (HTML Supported).
- * @property {Number} priority - the priority of the message specified by Avail.
  * @property {[RouteObject]} routes - list of routes affected by this message, empty if message is general.
  */
 
@@ -24,7 +23,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
  * - Will return `null` if an error occurs during fetching.
  * - Will re-fetch and re-process data periodically.
  * - Will apply filtering by route abbreviation if provided, always letting general messages through.
- * - Will sort public messages by priority, then the lowest sort order of its affected routes (general messages last).
+ * - Will sort public messages by the lowest sort order of its affected routes (general messages last).
  *
  * @param {URL} infoPoint - the URL of the InfoPoint API from which to get public message data.
  * @param {[String]|null} routes - a list of route abbreviations to whitelist, null if no filtering is to be applied.
@@ -104,7 +103,7 @@ function filterPublicMessages (publicMessages, routeAbbreviations) {
 }
 
 /**
- * Sorts public messages by priority, then the lowest sort order of its affected routes (general messages last).
+ * Sorts public messages by the lowest sort order of its affected routes (general messages last).
  *
  * @param {[{}]} publicMessages - raw public message data.
  * @return {[{}]}
@@ -122,10 +121,6 @@ function sortPublicMessages (publicMessages) {
       return sortOrder1 - sortOrder2
     }),
   })).sort((message1, message2) => {
-    const priority1 = ensureComparable(message1['Priority'])
-    const priority2 = ensureComparable(message2['Priority'])
-    if (priority1 !== priority2) return priority1 - priority2
-
     const routeSortOrder1 = minimumComparable(message1['Routes'].map((route) => ensureComparable(route['SortOrder'])))
     const routeSortOrder2 = minimumComparable(message2['Routes'].map((route) => ensureComparable(route['SortOrder'])))
     return routeSortOrder1 - routeSortOrder2
@@ -143,7 +138,6 @@ function normalizePublicMessages (publicMessages) {
   return publicMessages.map((message) => ({
     id: message['MessageId'],
     message: message['Message'],
-    priority: message['Priority'],
     routes: message['Routes'].map((route) => ({
       id: route['RouteId'],
       abbreviation: route['RouteAbbreviation'],


### PR DESCRIPTION
I personally haven't ever seen a message that didn't have the default priority.

Furthermore, Swiftly doesn't really have an equivalent field on its "alerts". For a smooth switchover we're going to have to support both data sources for some period of time and it'll make it easier to just do away with this now.

